### PR TITLE
Updating to latest html-autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "event-stream": "^3.1.7",
-    "html-autoprefixer": "^0.3.5"
+    "html-autoprefixer": "^0.3.8"
   }
 }


### PR DESCRIPTION
Hi guys,

Thanks for this useful package! I noticed that it's out of sync with html-autoprefixer and bumped the version.

Also the [release](https://www.npmjs.com/package/gulp-html-autoprefixer) on npm is still 0.0.1. It would be great if you could you push an update as well!

Thank you,

Radek