### PR TITLE
Pass autoprefixer options

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,11 +3,11 @@
 var htmlAutoprefixer = require('html-autoprefixer');
 var es = require('event-stream');
 
-module.exports = function() {
+module.exports = function(autoprefixerConfig) {
   return es.map(function(file, done) {
     var htmlString = file.contents.toString();
 
-    var prefixed = htmlAutoprefixer.process(htmlString);
+    var prefixed = htmlAutoprefixer(autoprefixerConfig).process(htmlString);
     file.contents = new Buffer(prefixed);
 
     next();


### PR DESCRIPTION
This change depends on https://github.com/Rebelmail/html-autoprefixer/pull/20 and makes it possible to pass a configuration object to autoprefixer.
